### PR TITLE
call zeit webhook on update

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+ZEIT_WEBHOOK_URL=http://example.com

--- a/Gemfile
+++ b/Gemfile
@@ -16,16 +16,19 @@ gem 'friendly_id', '~> 5.2.4'
 gem 'graphql'
 gem 'graphql-batch'
 gem 'hiredis'
+gem 'httparty'
 gem 'pg'
 gem 'puma', '~> 4.1'
 gem 'rack-cors'
 gem 'rails', '~> 6.0.2'
+gem 'rails-observers'
 gem 'redis'
 gem 'rollbar'
 
 group :test do
   gem 'database_cleaner-active_record'
   gem 'shoulda-matchers'
+  gem 'webmock'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,8 @@ GEM
       zeitwerk (~> 2.2)
     acts-as-taggable-on (6.5.0)
       activerecord (>= 5.0, < 6.1)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     arbre (1.2.1)
       activesupport (>= 3.0.0)
     ast (2.4.0)
@@ -99,6 +101,8 @@ GEM
       i18n_data (~> 0.10.0)
       sixarm_ruby_unaccent (~> 1.1)
       unicode_utils (~> 1.4)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.6)
     database_cleaner (1.8.3)
     database_cleaner-active_record (1.8.0)
@@ -139,7 +143,11 @@ GEM
     has_scope (0.7.2)
       actionpack (>= 4.1)
       activesupport (>= 4.1)
+    hashdiff (1.0.1)
     hiredis (0.6.3)
+    httparty (0.18.0)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     i18n_data (0.10.0)
@@ -177,11 +185,15 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.1009)
     mimemagic (0.3.4)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
     msgpack (1.3.3)
+    multi_xml (0.6.0)
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
@@ -201,6 +213,7 @@ GEM
       pry (~> 0.10)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
+    public_suffix (4.0.4)
     puma (4.3.3)
       nio4r (~> 2.0)
     rack (2.2.2)
@@ -228,6 +241,8 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-observers (0.1.5)
+      activemodel (>= 4.0)
     railties (6.0.2.1)
       actionpack (= 6.0.2.1)
       activesupport (= 6.0.2.1)
@@ -284,6 +299,7 @@ GEM
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
+    safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -324,6 +340,10 @@ GEM
     unicode_utils (1.4.0)
     warden (1.2.8)
       rack (>= 2.0.6)
+    webmock (3.8.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -354,6 +374,7 @@ DEPENDENCIES
   graphql
   graphql-batch
   hiredis
+  httparty
   listen (>= 3.0.5, < 3.2)
   pg
   pry-byebug
@@ -361,6 +382,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rack-cors
   rails (~> 6.0.2)
+  rails-observers
   redis
   rollbar
   rspec-rails
@@ -370,6 +392,7 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
+  webmock
 
 RUBY VERSION
    ruby 2.6.6p146

--- a/app/observers/zeit_observer.rb
+++ b/app/observers/zeit_observer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ZeitObserver < ActiveRecord::Observer
+  observe Organization, Organization::OpeningHour, Organization::SubdivisionConnection, Country, Country::Subdivision
+
+  def after_save(_record)
+    HTTParty.get(ENV['ZEIT_WEBHOOK_URL']) unless Rails.env.development?
+  end
+
+  def after_destroy(_record)
+    HTTParty.get(ENV['ZEIT_WEBHOOK_URL']) unless Rails.env.development?
+  end
+end

--- a/app/observers/zeit_observer.rb
+++ b/app/observers/zeit_observer.rb
@@ -4,10 +4,10 @@ class ZeitObserver < ActiveRecord::Observer
   observe Organization, Organization::OpeningHour, Organization::SubdivisionConnection, Country, Country::Subdivision
 
   def after_save(_record)
-    HTTParty.get(ENV['ZEIT_WEBHOOK_URL']) unless Rails.env.development?
+    HTTParty.post(ENV['ZEIT_WEBHOOK_URL']) unless Rails.env.development?
   end
 
   def after_destroy(_record)
-    HTTParty.get(ENV['ZEIT_WEBHOOK_URL']) unless Rails.env.development?
+    HTTParty.post(ENV['ZEIT_WEBHOOK_URL']) unless Rails.env.development?
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,5 +43,6 @@ module Helpline
     config.cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] }
     config.session_store :cache_store, key: '_helpline_session'
     config.middleware.use config.session_store, config.session_options
+    config.active_record.observers = :zeit_observer
   end
 end

--- a/spec/lib/factory_bot_spec.rb
+++ b/spec/lib/factory_bot_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe FactoryBot do
+  it 'lints factories successfully' do
+    described_class.lint
+  end
+end

--- a/spec/models/country/subdivision_spec.rb
+++ b/spec/models/country/subdivision_spec.rb
@@ -47,4 +47,42 @@ RSpec.describe Country::Subdivision, type: :model do
       expect(subdivision.iso_3166_subdivision).to eq ISO3166::Country.new('US').subdivisions['AL']
     end
   end
+
+  describe '#after_create' do
+    subject(:subdivision) { build(:country_subdivision, country: country) }
+
+    let!(:country) { create(:country, code: 'US') }
+    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+
+    it 'calls ZEIT_WEBHOOK_URL' do
+      WebMock.reset_executed_requests!
+      subdivision.save
+      expect(stub).to have_been_requested.once
+    end
+  end
+
+  describe '#after_save' do
+    subject!(:subdivision) { create(:country_subdivision, country: country, code: 'AL') }
+
+    let!(:country) { create(:country, code: 'US') }
+    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+
+    it 'calls ZEIT_WEBHOOK_URL' do
+      WebMock.reset_executed_requests!
+      subdivision.update(code: 'FL')
+      expect(stub).to have_been_requested.once
+    end
+  end
+
+  describe '#after_destroy' do
+    subject!(:subdivision) { create(:country_subdivision) }
+
+    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+
+    it 'calls ZEIT_WEBHOOK_URL' do
+      WebMock.reset_executed_requests!
+      subdivision.destroy
+      expect(stub).to have_been_requested.once
+    end
+  end
 end

--- a/spec/models/country/subdivision_spec.rb
+++ b/spec/models/country/subdivision_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Country::Subdivision, type: :model do
     subject(:subdivision) { build(:country_subdivision, country: country) }
 
     let!(:country) { create(:country, code: 'US') }
-    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+    let!(:stub) { stub_request(:post, ENV['ZEIT_WEBHOOK_URL']) }
 
     it 'calls ZEIT_WEBHOOK_URL' do
       WebMock.reset_executed_requests!
@@ -65,7 +65,7 @@ RSpec.describe Country::Subdivision, type: :model do
     subject!(:subdivision) { create(:country_subdivision, country: country, code: 'AL') }
 
     let!(:country) { create(:country, code: 'US') }
-    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+    let!(:stub) { stub_request(:post, ENV['ZEIT_WEBHOOK_URL']) }
 
     it 'calls ZEIT_WEBHOOK_URL' do
       WebMock.reset_executed_requests!
@@ -77,7 +77,7 @@ RSpec.describe Country::Subdivision, type: :model do
   describe '#after_destroy' do
     subject!(:subdivision) { create(:country_subdivision) }
 
-    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+    let!(:stub) { stub_request(:post, ENV['ZEIT_WEBHOOK_URL']) }
 
     it 'calls ZEIT_WEBHOOK_URL' do
       WebMock.reset_executed_requests!

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -33,4 +33,40 @@ RSpec.describe Country, type: :model do
       expect(country.iso_3166_country).to eq ISO3166::Country.new('US')
     end
   end
+
+  describe '#after_create' do
+    subject(:country) { build(:country) }
+
+    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+
+    it 'calls ZEIT_WEBHOOK_URL' do
+      WebMock.reset_executed_requests!
+      country.save
+      expect(stub).to have_been_requested.once
+    end
+  end
+
+  describe '#after_save' do
+    subject!(:country) { create(:country) }
+
+    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+
+    it 'calls ZEIT_WEBHOOK_URL' do
+      WebMock.reset_executed_requests!
+      country.update(code: 'NZ')
+      expect(stub).to have_been_requested.once
+    end
+  end
+
+  describe '#after_destroy' do
+    subject!(:country) { create(:country) }
+
+    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+
+    it 'calls ZEIT_WEBHOOK_URL' do
+      WebMock.reset_executed_requests!
+      country.destroy
+      expect(stub).to have_been_requested.once
+    end
+  end
 end

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Country, type: :model do
   describe '#after_create' do
     subject(:country) { build(:country) }
 
-    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+    let!(:stub) { stub_request(:post, ENV['ZEIT_WEBHOOK_URL']) }
 
     it 'calls ZEIT_WEBHOOK_URL' do
       WebMock.reset_executed_requests!
@@ -49,7 +49,7 @@ RSpec.describe Country, type: :model do
   describe '#after_save' do
     subject!(:country) { create(:country) }
 
-    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+    let!(:stub) { stub_request(:post, ENV['ZEIT_WEBHOOK_URL']) }
 
     it 'calls ZEIT_WEBHOOK_URL' do
       WebMock.reset_executed_requests!
@@ -61,7 +61,7 @@ RSpec.describe Country, type: :model do
   describe '#after_destroy' do
     subject!(:country) { create(:country) }
 
-    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+    let!(:stub) { stub_request(:post, ENV['ZEIT_WEBHOOK_URL']) }
 
     it 'calls ZEIT_WEBHOOK_URL' do
       WebMock.reset_executed_requests!

--- a/spec/models/organization/opening_hour_spec.rb
+++ b/spec/models/organization/opening_hour_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Organization::OpeningHour, type: :model do
     subject(:opening_hour) { build(:organization_opening_hour, organization: organization) }
 
     let!(:organization) { create(:organization) }
-    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+    let!(:stub) { stub_request(:post, ENV['ZEIT_WEBHOOK_URL']) }
 
     it 'calls ZEIT_WEBHOOK_URL' do
       WebMock.reset_executed_requests!
@@ -42,7 +42,7 @@ RSpec.describe Organization::OpeningHour, type: :model do
   describe '#after_save' do
     subject!(:opening_hour) { create(:organization_opening_hour) }
 
-    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+    let!(:stub) { stub_request(:post, ENV['ZEIT_WEBHOOK_URL']) }
 
     it 'calls ZEIT_WEBHOOK_URL' do
       WebMock.reset_executed_requests!
@@ -54,7 +54,7 @@ RSpec.describe Organization::OpeningHour, type: :model do
   describe '#after_destroy' do
     subject!(:opening_hour) { create(:organization_opening_hour) }
 
-    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+    let!(:stub) { stub_request(:post, ENV['ZEIT_WEBHOOK_URL']) }
 
     it 'calls ZEIT_WEBHOOK_URL' do
       WebMock.reset_executed_requests!

--- a/spec/models/organization/opening_hour_spec.rb
+++ b/spec/models/organization/opening_hour_spec.rb
@@ -25,4 +25,41 @@ RSpec.describe Organization::OpeningHour, type: :model do
 
     it { is_expected.not_to be_valid }
   end
+
+  describe '#after_create' do
+    subject(:opening_hour) { build(:organization_opening_hour, organization: organization) }
+
+    let!(:organization) { create(:organization) }
+    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+
+    it 'calls ZEIT_WEBHOOK_URL' do
+      WebMock.reset_executed_requests!
+      opening_hour.save
+      expect(stub).to have_been_requested.once
+    end
+  end
+
+  describe '#after_save' do
+    subject!(:opening_hour) { create(:organization_opening_hour) }
+
+    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+
+    it 'calls ZEIT_WEBHOOK_URL' do
+      WebMock.reset_executed_requests!
+      opening_hour.update(day: 'tuesday')
+      expect(stub).to have_been_requested.once
+    end
+  end
+
+  describe '#after_destroy' do
+    subject!(:opening_hour) { create(:organization_opening_hour) }
+
+    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+
+    it 'calls ZEIT_WEBHOOK_URL' do
+      WebMock.reset_executed_requests!
+      opening_hour.destroy
+      expect(stub).to have_been_requested.once
+    end
+  end
 end

--- a/spec/models/organization/subdivision_connection_spec.rb
+++ b/spec/models/organization/subdivision_connection_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Organization::SubdivisionConnection, type: :model do
 
     let!(:organization) { create(:organization) }
     let!(:subdivision) { create(:country_subdivision) }
-    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+    let!(:stub) { stub_request(:post, ENV['ZEIT_WEBHOOK_URL']) }
 
     it 'calls ZEIT_WEBHOOK_URL' do
       WebMock.reset_executed_requests!
@@ -28,7 +28,7 @@ RSpec.describe Organization::SubdivisionConnection, type: :model do
   describe '#after_destroy' do
     subject!(:subdivision_connection) { create(:organization_subdivision_connection) }
 
-    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+    let!(:stub) { stub_request(:post, ENV['ZEIT_WEBHOOK_URL']) }
 
     it 'calls ZEIT_WEBHOOK_URL' do
       WebMock.reset_executed_requests!

--- a/spec/models/organization/subdivision_connection_spec.rb
+++ b/spec/models/organization/subdivision_connection_spec.rb
@@ -8,4 +8,32 @@ RSpec.describe Organization::SubdivisionConnection, type: :model do
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:subdivision) }
   it { is_expected.to validate_uniqueness_of(:organization_id).scoped_to(:subdivision_id).case_insensitive }
+
+  describe '#after_create' do
+    subject(:subdivision_connection) do
+      build(:organization_subdivision_connection, organization: organization, subdivision: subdivision)
+    end
+
+    let!(:organization) { create(:organization) }
+    let!(:subdivision) { create(:country_subdivision) }
+    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+
+    it 'calls ZEIT_WEBHOOK_URL' do
+      WebMock.reset_executed_requests!
+      subdivision_connection.save
+      expect(stub).to have_been_requested.once
+    end
+  end
+
+  describe '#after_destroy' do
+    subject!(:subdivision_connection) { create(:organization_subdivision_connection) }
+
+    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+
+    it 'calls ZEIT_WEBHOOK_URL' do
+      WebMock.reset_executed_requests!
+      subdivision_connection.destroy
+      expect(stub).to have_been_requested.once
+    end
+  end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Organization, type: :model do
     subject(:organization) { build(:organization, country: country) }
 
     let!(:country) { create(:country) }
-    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+    let!(:stub) { stub_request(:post, ENV['ZEIT_WEBHOOK_URL']) }
 
     it 'calls ZEIT_WEBHOOK_URL' do
       WebMock.reset_executed_requests!
@@ -99,7 +99,7 @@ RSpec.describe Organization, type: :model do
   describe '#after_save' do
     subject!(:organization) { create(:organization) }
 
-    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+    let!(:stub) { stub_request(:post, ENV['ZEIT_WEBHOOK_URL']) }
 
     it 'calls ZEIT_WEBHOOK_URL' do
       WebMock.reset_executed_requests!
@@ -111,7 +111,7 @@ RSpec.describe Organization, type: :model do
   describe '#after_destroy' do
     subject!(:organization) { create(:organization) }
 
-    let!(:stub) { stub_request(:get, ENV['ZEIT_WEBHOOK_URL']) }
+    let!(:stub) { stub_request(:post, ENV['ZEIT_WEBHOOK_URL']) }
 
     it 'calls ZEIT_WEBHOOK_URL' do
       WebMock.reset_executed_requests!

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,8 @@ require File.expand_path('../config/environment', __dir__)
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'webmock/rspec'
+WebMock.disable_net_connect!(allow_localhost: true)
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -4,7 +4,6 @@ require 'database_cleaner'
 
 RSpec.configure do |config|
   config.before(:suite) do
-    FactoryBot.lint unless config.files_to_run.one?
     DatabaseCleaner.clean_with(:truncation)
   end
 

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.before do
+    stub_request(:get, 'http://example.com/')
+      .with(
+        headers: {
+          'Accept' => '*/*',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'User-Agent' => 'Ruby'
+        }
+      )
+      .to_return(status: 200, body: '', headers: {})
+  end
+end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -2,7 +2,7 @@
 
 RSpec.configure do |config|
   config.before do
-    stub_request(:get, 'http://example.com/')
+    stub_request(:post, ENV['ZEIT_WEBHOOK_URL'])
       .with(
         headers: {
           'Accept' => '*/*',


### PR DESCRIPTION
Everytime organization, country and associations are created, updated or deleted we should send a call off to ZEIT_WEBHOOK_URL to rebuild.