### PR TITLE
filter organizations when subdivisions empty

### DIFF
--- a/app/graphql/queries/organizations_query.rb
+++ b/app/graphql/queries/organizations_query.rb
@@ -5,7 +5,10 @@ module Queries
     description 'Find all organizations'
 
     argument :country_code, String, required: false, description: 'Filter by countryCode'
-    argument :subdivision_codes, [String], required: false, description: 'Filter by subdivisionCodes'
+    argument :subdivision_codes,
+             [String],
+             required: false,
+             description: 'Filter by subdivisionCodes (when empty will return organizations with no subdivisions'
     argument :categories, [String], required: false, description: 'Filter by categories'
     argument :human_support_types, [String], required: false, description: 'Filter by humanSupportTypes'
     argument :topics, [String], required: false, description: 'Filter by topics'

--- a/app/models/concerns/filterable.rb
+++ b/app/models/concerns/filterable.rb
@@ -7,7 +7,7 @@ module Filterable
     def filter(filtering_params)
       results = where(nil)
       filtering_params.each do |key, value|
-        results = results.public_send("filter_by_#{key}", value) if value.present?
+        results = results.public_send("filter_by_#{key}", value) if value.present? || value.kind_of?(Array)
       end
       results
     end

--- a/app/models/concerns/filterable.rb
+++ b/app/models/concerns/filterable.rb
@@ -7,7 +7,7 @@ module Filterable
     def filter(filtering_params)
       results = where(nil)
       filtering_params.each do |key, value|
-        results = results.public_send("filter_by_#{key}", value) if value.present? || value.kind_of?(Array)
+        results = results.public_send("filter_by_#{key}", value) if value.present? || value.is_a?(Array)
       end
       results
     end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -16,8 +16,13 @@ class Organization < ApplicationRecord
   validates :timezone, inclusion: { in: ActiveSupport::TimeZone.all.map(&:name) }, presence: true
   accepts_nested_attributes_for :opening_hours, allow_destroy: true
   scope :filter_by_country_code, ->(code) { joins(:country).where(countries: { code: code.upcase }) }
-  scope :filter_by_subdivision_codes,
-        ->(codes) { joins(:subdivisions).where(country_subdivisions: { code: codes.map(&:upcase) }) }
+  scope :filter_by_subdivision_codes, lambda { |codes|
+    if codes.empty?
+      left_outer_joins(:subdivisions).where(country_subdivisions: { id: nil })
+    else
+      joins(:subdivisions).where(country_subdivisions: { code: codes.map(&:upcase) })
+    end
+  }
   scope :filter_by_categories, ->(tags) { tagged_with(tags, on: :categories) }
   scope :filter_by_human_support_types, ->(tags) { tagged_with(tags, on: :human_support_types) }
   scope :filter_by_topics, ->(tags) { tagged_with(tags, on: :topics) }

--- a/spec/graphql/queries/organizations_query_spec.rb
+++ b/spec/graphql/queries/organizations_query_spec.rb
@@ -66,6 +66,14 @@ RSpec.describe Queries::OrganizationsQuery, type: :request do
       ]
     end
 
+    it 'returns organizations filtered by empty subdivison_codes' do
+      post '/', params: { query: query('(countryCode: "NZ", subdivisionCodes: [])') }
+
+      expect(data).to match_array [
+        hash_including(attributes_1)
+      ]
+    end
+
     it 'returns organizations filtered by categories' do
       post '/', params: { query: query('(categories: ["category_0"])') }
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -57,6 +57,10 @@ RSpec.describe Organization, type: :model do
       it 'returns organizations' do
         expect(described_class.filter_by_country_code('nz')).to match_array [organization_1, organization_2]
       end
+
+      it 'allows use by filter' do
+        expect(described_class.filter(country_code: 'nz')).to match_array [organization_1, organization_2]
+      end
     end
 
     describe '.filter_by_subdivison_codes' do
@@ -64,10 +68,18 @@ RSpec.describe Organization, type: :model do
         expect(described_class.filter_by_subdivision_codes(['auk'])).to match_array [organization_2]
       end
 
-      it 'allows empty array' do
+      it 'allows use by filter' do
+        expect(described_class.filter(subdivision_codes: ['auk'])).to match_array [organization_2]
+      end
+
+      it 'returns organizations when empty' do
         expect(
           described_class.filter_by_country_code('nz').filter_by_subdivision_codes([])
         ).to match_array [organization_1]
+      end
+
+      it 'allows use by filter when empty' do
+        expect(described_class.filter(country_code: 'nz', subdivision_codes: [])).to match_array [organization_1]
       end
     end
 
@@ -75,17 +87,29 @@ RSpec.describe Organization, type: :model do
       it 'returns organizations' do
         expect(described_class.filter_by_categories(['category_0'])).to match_array [organization_0]
       end
+
+      it 'allows use by filter' do
+        expect(described_class.filter(categories: ['category_0'])).to match_array [organization_0]
+      end
     end
 
     describe '.filter_by_human_support_type' do
       it 'returns organizations' do
         expect(described_class.filter_by_human_support_types(['human_support_type_0'])).to match_array [organization_0]
       end
+
+      it 'allows use by filter' do
+        expect(described_class.filter(human_support_types: ['human_support_type_0'])).to match_array [organization_0]
+      end
     end
 
     describe '.filter_by_topics' do
       it 'returns organizations' do
         expect(described_class.filter_by_topics(['topic_0'])).to match_array [organization_0]
+      end
+
+      it 'allows use by filter' do
+        expect(described_class.filter(topics: ['topic_0'])).to match_array [organization_0]
       end
     end
   end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -63,6 +63,12 @@ RSpec.describe Organization, type: :model do
       it 'returns organizations' do
         expect(described_class.filter_by_subdivision_codes(['auk'])).to match_array [organization_2]
       end
+
+      it 'allows empty array' do
+        expect(
+          described_class.filter_by_country_code('nz').filter_by_subdivision_codes([])
+        ).to match_array [organization_1]
+      end
     end
 
     describe '.filter_by_categories' do


### PR DESCRIPTION
if filter_by_subdivisions is empty it should only return organizations without a subdivision connect (national helplines only).